### PR TITLE
Move config consts out of src files and into a conf.yaml 

### DIFF
--- a/app.go
+++ b/app.go
@@ -1,5 +1,7 @@
 package carrot
 
+var config = getConfig() // parse conf.yaml and instantiate Config
+
 func Run() {
 	sessions := NewDefaultSessionManager()
 	server := NewServer(sessions)

--- a/app.go
+++ b/app.go
@@ -1,8 +1,9 @@
 package carrot
 
-var config = getConfig() // parse conf.yaml and instantiate Config
+var config Config
 
 func Run() {
+	config = getConfig() // parse conf.yaml and instantiate Config
 	sessions := NewDefaultSessionManager()
 	server := NewServer(sessions)
 	dispatcher := NewDispatcher()

--- a/client.go
+++ b/client.go
@@ -11,7 +11,7 @@ import (
 )
 
 var (
-	clientConfig = config.Client
+	clientConfig     = config.Client
 	writeWaitSeconds = clientConfig.WriteWaitSecs
 	pongWaitSeconds  = clientConfig.PongWaitSecs
 

--- a/client.go
+++ b/client.go
@@ -10,9 +10,22 @@ import (
 	"time"
 )
 
-const (
-	writeWaitSeconds = 600
-	pongWaitSeconds  = 600
+var (
+	clientConfig = config.Client
+	writeWaitSeconds = clientConfig.WriteWaitSecs
+	pongWaitSeconds  = clientConfig.PongWaitSecs
+
+	// maximum message size allowed from the websocket
+	maxMessageSize = clientConfig.MaxMessageSize
+
+	// toggle to require a client secret token on WS upgrade request
+	clientSecretRequired = clientConfig.ClientSecretRequired
+
+	// size of client send channel
+	sendMsgBufferSize = clientConfig.SendMessageBufferSize
+
+	// size of sendToken channel
+	sendTokenBufferSize = clientConfig.SendTokenBufferSize
 
 	// time allowed to write a message to the websocket
 	writeWait = writeWaitSeconds * time.Second
@@ -22,18 +35,6 @@ const (
 
 	// send pings to the websocket with this period, must be less than pongWait
 	pingPeriod = (pongWait * 9) / 10
-
-	// maximum message size allowed from the websocket
-	maxMessageSize = 65536
-
-	// toggle to require a client secret token on WS upgrade request
-	clientSecretRequired = false
-
-	// size of client send channel
-	sendMsgBufferSize = 1
-
-	// size of sendToken channel
-	sendTokenBufferSize = 1
 )
 
 var (

--- a/conf.yaml
+++ b/conf.yaml
@@ -1,0 +1,25 @@
+server:
+  server_secret: "37FUqWlvJhRgwPMM1mlHOGyPNwkVna3b"
+  broadcast_channel_size: 4096
+  port: 8080
+
+session:
+  nil_session_token: ""
+  default_sess_closed_timeout_duration_secs: 10
+
+router:
+  route_delimiter: "_"
+  stream_identifier: "StreamController"
+  controller_identifier: "Controller"
+  do_cache_controllers: true
+
+client:
+  write_wait_secs: 600
+  pong_wait_secs: 600
+  max_message_size: 65536
+  client_secret_required: false
+  send_msg_buffer_size: 1
+  send_token_buffer_size: 1
+
+middleware:
+  input_channel_size: 256

--- a/conf.yaml
+++ b/conf.yaml
@@ -1,5 +1,5 @@
 server:
-  server_secret: "37FUqWlvJhRgwPMM1mlHOGyPNwkVna3b"
+  server_secret: "37FUqWlvJhRgwPMM1mlHOGyPNwkVna3b" // TODO: Change this because using a default secret is insecure
   broadcast_channel_size: 4096
   port: 8080
 
@@ -11,6 +11,8 @@ router:
   route_delimiter: "_"
   stream_identifier: "StreamController"
   controller_identifier: "Controller"
+
+dispatcher:
   do_cache_controllers: true
 
 client:

--- a/config.go
+++ b/config.go
@@ -27,7 +27,9 @@ type Config struct {
 		RouteDelimiter       string `yaml:"route_delimiter"`
 		StreamIdentifier     string `yaml:"stream_identifier"`
 		ControllerIdentifier string `yaml:"controller_identifier"`
-		DoCacheControllers   bool   `yaml:"do_cache_controllers"`
+	}
+	Dispatcher struct {
+		DoCacheControllers bool `yaml:"do_cache_controllers"`
 	}
 	Client struct {
 		SendMessageBufferSize int           `yaml:"send_msg_buffer_size"`

--- a/config.go
+++ b/config.go
@@ -1,0 +1,60 @@
+package carrot
+
+import (
+	"gopkg.in/yaml.v2"
+	"sync"
+	"io/ioutil"
+	"log"
+	"time"
+)
+
+var (
+	once     sync.Once
+	instance Config
+)
+
+type Config struct {
+	Server struct {
+		BroadcastChannelSize int    `yaml:"broadcast_channel_size"`
+		Port                 int    `yaml:"port"`
+		ServerSecret         string `yaml:"server_secret"`
+	}
+	Session struct {
+		NilSessionToken                     SessionToken  `yaml:"nil_session_token"`
+		DefaultSessionClosedTimeoutDuration time.Duration `yaml:"default_sess_closed_timeout_duration_secs"`
+	}
+	Router struct {
+		RouteDelimiter       string `yaml:"route_delimiter"`
+		StreamIdentifier     string `yaml:"stream_identifier"`
+		ControllerIdentifier string `yaml:"controller_identifier"`
+		DoCacheControllers   bool   `yaml:"do_cache_controllers"`
+	}
+	Client struct {
+		SendMessageBufferSize int           `yaml:"send_msg_buffer_size"`
+		SendTokenBufferSize   int           `yaml:"send_token_buffer_size"`
+		MaxMessageSize        int64         `yaml:"maxMessageSize"`
+		ClientSecretRequired  bool          `yaml:"client_secret_required"`
+		WriteWaitSecs         time.Duration `yaml:"write_wait_secs"`
+		PongWaitSecs          time.Duration `yaml:"pong_wait_secs"`
+	}
+	Middleware struct {
+		InputChannelSize int `yaml:"input_channel_size"`
+	}
+}
+
+func getConfig() Config {
+	once.Do(func() {
+		instance = Config{}
+		yamlFile, err := ioutil.ReadFile("conf.yaml")
+		if err != nil {
+			log.Printf("yamlFile.Get err #%v ", err)
+		}
+
+		err = yaml.Unmarshal(yamlFile, &instance)
+		if err != nil {
+			log.Fatalf("Unmarshal: %v", err)
+		}
+	})
+
+	return instance
+}

--- a/config.go
+++ b/config.go
@@ -2,9 +2,9 @@ package carrot
 
 import (
 	"gopkg.in/yaml.v2"
-	"sync"
 	"io/ioutil"
 	"log"
+	"sync"
 	"time"
 )
 

--- a/dispatcher.go
+++ b/dispatcher.go
@@ -3,6 +3,7 @@ package carrot
 import (
 	"fmt"
 )
+
 var (
 	doCacheControllers = config.Router.DoCacheControllers
 )

--- a/dispatcher.go
+++ b/dispatcher.go
@@ -5,7 +5,7 @@ import (
 )
 
 var (
-	doCacheControllers = config.Router.DoCacheControllers
+	doCacheControllers = config.Dispatcher.DoCacheControllers
 )
 
 type Dispatcher struct {

--- a/dispatcher.go
+++ b/dispatcher.go
@@ -3,9 +3,8 @@ package carrot
 import (
 	"fmt"
 )
-
-const (
-	doCacheControllers bool = true
+var (
+	doCacheControllers = config.Router.DoCacheControllers
 )
 
 type Dispatcher struct {

--- a/middleware.go
+++ b/middleware.go
@@ -4,8 +4,9 @@ import (
 	"log"
 )
 
-const (
-	InputChannelSize = 256
+var (
+	middlewareConfig = config.Middleware
+	InputChannelSize = middlewareConfig.InputChannelSize
 )
 
 /*

--- a/router.go
+++ b/router.go
@@ -33,7 +33,6 @@ func getRouter() Router {
 			mutex:        &sync.Mutex{},
 		}
 	})
-	
 	return routerInstance
 }
 

--- a/router.go
+++ b/router.go
@@ -5,12 +5,6 @@ import (
 	"sync"
 )
 
-const (
-	routeDelimiter       = "_"
-	streamIdentifier     = "StreamController"
-	controllerIdentifier = "Controller"
-)
-
 type RoutingTable map[string]Route
 
 var (
@@ -39,7 +33,7 @@ func getRouter() Router {
 			mutex:        &sync.Mutex{},
 		}
 	})
-
+	
 	return routerInstance
 }
 

--- a/server.go
+++ b/server.go
@@ -8,7 +8,7 @@ import (
 )
 
 var (
-	serverConfig = config.Server
+	serverConfig         = config.Server
 	serverSecret         = serverConfig.ServerSecret
 	broadcastChannelSize = serverConfig.BroadcastChannelSize
 	port                 = serverConfig.Port

--- a/server.go
+++ b/server.go
@@ -7,10 +7,11 @@ import (
 	"net/http"
 )
 
-const (
-	serverSecret         = "37FUqWlvJhRgwPMM1mlHOGyPNwkVna3b"
-	broadcastChannelSize = 4096
-	port                 = 8080
+var (
+	serverConfig = config.Server
+	serverSecret         = serverConfig.ServerSecret
+	broadcastChannelSize = serverConfig.BroadcastChannelSize
+	port                 = serverConfig.Port
 )
 
 //the server maintains the list of clients and

--- a/session.go
+++ b/session.go
@@ -9,9 +9,10 @@ import (
 	"time"
 )
 
-const (
-	nilSessionToken                     = ""
-	defaultSessionClosedTimeoutDuration = 10 // seconds
+var (
+	sessionConfig                       = config.Session
+	nilSessionToken                     = sessionConfig.NilSessionToken
+	defaultSessionClosedTimeoutDuration = sessionConfig.DefaultSessionClosedTimeoutDuration // seconds
 )
 
 var (


### PR DESCRIPTION
This PR adds a conf.yaml file that will be parsed on app.go's `Run()`. This keeps all configuration in a single file instead of being spread across multiple sources.