### PR TITLE
fix test for windows server

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -35,6 +35,8 @@ func TestClientExpired(t *testing.T) {
 	client.session.expireTime = waitTime
 	client.softClose()
 
+	time.Sleep(time.Second)	// needed for test to pass on Windows
+
 	if client.Expired() == false {
 		t.Fatalf("client should be expired but it isn't")
 	}


### PR DESCRIPTION
### Description
Windows doesn't like the client expiration test, so this quick fix makes sure `TestClientExpired` passes when it should

### Impacted Areas in Application
List general components of the application that this PR will affect:
Testing.

### Todos
- [x] Tests
- [x] Documentation
